### PR TITLE
feat: add support for more architectures & fix errors

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -464,6 +464,14 @@ jobs:
         SOURCE_TAG="${{ needs.check-version.outputs.tag_name }}"
         
         # Prepare files for upload
+        
+        # Add debs 
+        DEBS_TO_UPLOAD="openlist-$VERSION-amd64.deb/openlist_${VERSION}-1_amd64.deb"
+        for arch in i386 arm64 armel armhf ppc64el riscv64 s390x loong64
+        do
+            DEBS_TO_UPLOAD="$DEBS_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
+        done
+
         cd apt-repo
         FILES_TO_UPLOAD="Packages Release install-apt.sh"
         
@@ -475,15 +483,7 @@ jobs:
         # Add keyring file if it exists
         if [ -f "openlist-archive-keyring.gpg" ]; then
           FILES_TO_UPLOAD="$FILES_TO_UPLOAD openlist-archive-keyring.gpg"
-        fi
-
-        # Add debs 
-        DEBS_TO_UPLOAD="openlist-$VERSION-amd64.deb/openlist_${VERSION}-1_amd64.deb"
-        for arch in i386 arm64 armel armhf ppc64el riscv64 s390x loong64
-        do
-            DEBS_TO_UPLOAD="$DEBS_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
-        done
-        
+        fi        
         cd ..
         
         # Create release with proper changelog

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -478,9 +478,10 @@ jobs:
         fi
 
         # Add debs 
+        DEBS_TO_UPLOAD=""
         for arch in amd64 i386 arm64 armel armhf ppc64el riscv64 s390x loong64
         do
-            FILES_TO_UPLOAD="$FILES_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
+            DEBS_TO_UPLOAD="DEBS_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
         done
         
         cd ..
@@ -669,6 +670,7 @@ jobs:
 
         ---
         **🔒 Security Note**: This repository is GPG-signed for package integrity verification. The automatic installation script will set up GPG verification by default. For maximum security, always use the GPG-verified installation methods." \
+          "$DEBS_TO_UPLOAD" \
           $(echo $FILES_TO_UPLOAD | sed 's|^|apt-repo/|g; s| | apt-repo/|g')
 
   upload-to-ppa:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -466,8 +466,8 @@ jobs:
         # Prepare files for upload
         
         # Add debs 
-        DEBS_TO_UPLOAD="openlist-$VERSION-amd64.deb/openlist_${VERSION}-1_amd64.deb"
-        for arch in i386 arm64 armel armhf ppc64el riscv64 s390x loong64
+        DEBS_TO_UPLOAD=""
+        for arch in amd64 i386 arm64 armel armhf ppc64el riscv64 s390x loong64
         do
             DEBS_TO_UPLOAD="$DEBS_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
         done

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -670,7 +670,7 @@ jobs:
 
         ---
         **🔒 Security Note**: This repository is GPG-signed for package integrity verification. The automatic installation script will set up GPG verification by default. For maximum security, always use the GPG-verified installation methods." \
-          "$DEBS_TO_UPLOAD" \
+          $DEBS_TO_UPLOAD \
           $(echo $FILES_TO_UPLOAD | sed 's|^|apt-repo/|g; s| | apt-repo/|g')
 
   upload-to-ppa:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -9,7 +9,7 @@ on:
       force_build:
         description: 'Force build even if no new version'
         required: false
-        default: 'false'
+        default: false
         type: boolean
       ppa_build_number:
         description: 'Custom PPA build number (e.g., 2 for 4.0.8-2ubuntu1~22.04.1)'

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: ['amd64', 'i386', 'arm64', 'armel', 'armhf', 'ppc64el', 'riscv64', 's390x', 'loong64']
     
     steps:
     - name: Checkout code
@@ -123,103 +123,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y debhelper devscripts build-essential wget jq
         
-        # Install cross-compilation tools for ARM64 if needed
-        if [ "${{ matrix.arch }}" = "arm64" ]; then
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-        fi
-        
     - name: Prepare and build DEB package
       run: |
         VERSION="${{ needs.check-version.outputs.version }}"
-        TAG_NAME="${{ needs.check-version.outputs.tag_name }}"
         ARCH="${{ matrix.arch }}"
         
-        # Validate inputs
-        if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-          echo "Error: VERSION is null or empty"
-          exit 1
-        fi
-        
-        if [ -z "$TAG_NAME" ] || [ "$TAG_NAME" = "null" ]; then
-          echo "Error: TAG_NAME is null or empty"
-          exit 1
-        fi
-        
-        # Ensure version is clean (no 'v' prefix) for debian package
-        CLEAN_VERSION=$(echo "$VERSION" | sed 's/^v//')
-        
-        echo "=== Version Information ==="
-        echo "Original TAG_NAME: $TAG_NAME"
-        echo "Extracted VERSION: $VERSION"
-        echo "Clean VERSION for debian: $CLEAN_VERSION"
-        echo "Architecture: $ARCH"
-        
-        # Validate clean version
-        if [[ ! "$CLEAN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
-          echo "Error: Clean version format is invalid: $CLEAN_VERSION"
-          exit 1
-        fi
-        
-        echo "=== Preparing debian package ==="
-        
-        # Update changelog with clean version (no 'v' prefix)
-        cat > debian/changelog << EOF
-        openlist ($CLEAN_VERSION-1) unstable; urgency=medium
-
-          * DEB package built from OpenListTeam/OpenList $TAG_NAME
-          * Automated build for $ARCH architecture
-          * Binary downloaded from official release
-
-         -- OpenList Team <openlistteam@gmail.com>  $(date -R)
-        EOF
-        
-        echo "Generated changelog:"
-        cat debian/changelog
-        
-        # Make scripts executable
-        chmod +x debian/rules
-        chmod +x debian/postinst
-        chmod +x debian/prerm
-        chmod +x debian/postrm
-        
-        echo "=== Pre-downloading binary (optional, debian/rules will download if missing) ==="
-        
-        # Try to pre-download the binary to speed up build
-        DOWNLOAD_URL="https://github.com/OpenListTeam/OpenList/releases/download/$TAG_NAME/openlist-linux-$ARCH.tar.gz"
-        echo "Pre-download URL: $DOWNLOAD_URL"
-        
-        if wget -O "openlist-linux-$ARCH.tar.gz" "$DOWNLOAD_URL" 2>/dev/null; then
-          echo "Pre-download successful"
-          ls -la openlist-linux-$ARCH.tar.gz
-        else
-          echo "Pre-download failed, debian/rules will handle download"
-        fi
-        
-        echo "=== Building DEB package ==="
-        
-        # Set environment variables for cross-compilation
-        export DEB_HOST_ARCH=$ARCH
-        export DEB_BUILD_OPTIONS="nocheck"
-        
-        # Set cross-compilation environment for ARM64
-        if [ "$ARCH" = "arm64" ]; then
-          export CC=aarch64-linux-gnu-gcc
-          export DEB_BUILD_PROFILES="cross"
-        fi
-        
-        echo "Building package with:"
-        echo "DEB_HOST_ARCH=$DEB_HOST_ARCH"
-        echo "DEB_BUILD_OPTIONS=$DEB_BUILD_OPTIONS"
-        echo "CC=$CC"
-        echo "DEB_BUILD_PROFILES=$DEB_BUILD_PROFILES"
-        echo "Package version: $CLEAN_VERSION-1"
-        
-        # Verify current directory before build
-        echo "Files in current directory before build:"
-        ls -la
-        
-        # Build the package
-        dpkg-buildpackage -us -uc -a$ARCH
+        # Perform build
+        bash build.sh -v "$VERSION" -a "$ARCH"
         
         echo "=== Build completed ==="
         echo "Generated files:"
@@ -294,8 +204,10 @@ jobs:
         cd apt-repo
         
         # Copy DEB files
-        cp ../openlist-$VERSION-amd64.deb/openlist_${VERSION}-1_amd64.deb .
-        cp ../openlist-$VERSION-arm64.deb/openlist_${VERSION}-1_arm64.deb .
+        for arch in amd64 i386 arm64 armel armhf ppc64el riscv64 s390x loong64
+        do
+          cp ../openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb .
+        done
         
         echo "DEB files for APT repository:"
         ls -la *.deb
@@ -306,7 +218,7 @@ jobs:
         APT::FTPArchive::Release::Label "OpenList APT Repository";
         APT::FTPArchive::Release::Suite "./";
         APT::FTPArchive::Release::Codename "openlist";
-        APT::FTPArchive::Release::Architectures "amd64 arm64";
+        APT::FTPArchive::Release::Architectures "amd64 i386 arm64 armel armhf ppc64el riscv64 s390x loong64";
         APT::FTPArchive::Release::Components "";
         APT::FTPArchive::Release::Description "OpenList APT Repository for direct GitHub Release access";
         EOF
@@ -578,7 +490,7 @@ jobs:
         - **Source**: OpenListTeam/OpenList $SOURCE_TAG
         - **Package Version**: $VERSION-1
         - **Build Date**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
-        - **Architectures**: AMD64, ARM64
+        - **Architectures**: amd64, i386, arm64, armel, armhf, ppc64el, riscv64, s390x, loong64
         - **GPG Signed**: $([ -f apt-repo/Release.gpg ] && echo '✅ Yes' || echo '❌ No')
         - **Repository Format**: APT-compatible with GPG signature verification
 

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -478,8 +478,8 @@ jobs:
         fi
 
         # Add debs 
-        DEBS_TO_UPLOAD=""
-        for arch in amd64 i386 arm64 armel armhf ppc64el riscv64 s390x loong64
+        DEBS_TO_UPLOAD="openlist-$VERSION-amd64.deb/openlist_${VERSION}-1_amd64.deb"
+        for arch in i386 arm64 armel armhf ppc64el riscv64 s390x loong64
         do
             DEBS_TO_UPLOAD="$DEBS_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
         done

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -481,7 +481,7 @@ jobs:
         DEBS_TO_UPLOAD=""
         for arch in amd64 i386 arm64 armel armhf ppc64el riscv64 s390x loong64
         do
-            DEBS_TO_UPLOAD="DEBS_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
+            DEBS_TO_UPLOAD="$DEBS_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
         done
         
         cd ..

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -9,7 +9,7 @@ on:
       force_build:
         description: 'Force build even if no new version'
         required: false
-        default: false
+        default: 'false'
         type: boolean
       ppa_build_number:
         description: 'Custom PPA build number (e.g., 2 for 4.0.8-2ubuntu1~22.04.1)'

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -137,7 +137,7 @@ jobs:
         ls -la *.deb || echo "No .deb files found in current directory"
         
         # The package should be named with the clean version
-        EXPECTED_DEB="openlist_${CLEAN_VERSION}-1_${ARCH}.deb"
+        EXPECTED_DEB="openlist_${VERSION}-1_${ARCH}.deb"
         if [ -f "$EXPECTED_DEB" ]; then
           echo "Successfully built: $EXPECTED_DEB"
         elif [ -f "../$EXPECTED_DEB" ]; then

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -476,6 +476,12 @@ jobs:
         if [ -f "openlist-archive-keyring.gpg" ]; then
           FILES_TO_UPLOAD="$FILES_TO_UPLOAD openlist-archive-keyring.gpg"
         fi
+
+        # Add debs 
+        for arch in amd64 i386 arm64 armel armhf ppc64el riscv64 s390x loong64
+        do
+            FILES_TO_UPLOAD="$FILES_TO_UPLOAD openlist-$VERSION-$arch.deb/openlist_${VERSION}-1_$arch.deb"
+        done
         
         cd ..
         
@@ -663,8 +669,6 @@ jobs:
 
         ---
         **🔒 Security Note**: This repository is GPG-signed for package integrity verification. The automatic installation script will set up GPG verification by default. For maximum security, always use the GPG-verified installation methods." \
-          openlist-$VERSION-amd64.deb/openlist_${VERSION}-1_amd64.deb \
-          openlist-$VERSION-arm64.deb/openlist_${VERSION}-1_arm64.deb \
           $(echo $FILES_TO_UPLOAD | sed 's|^|apt-repo/|g; s| | apt-repo/|g')
 
   upload-to-ppa:

--- a/build.sh
+++ b/build.sh
@@ -201,7 +201,7 @@ cat > debian/changelog << EOF
 openlist ($CLEAN_VERSION-1) unstable; urgency=medium
 
   * DEB package built from OpenListTeam/OpenList $TAG_NAME
-  * Automated build for $ARCH architecture
+  * Automated build for $DPKG_ARCH architecture
   * Binary downloaded from official release
 
  -- OpenListTeam <openlistteam@gmail.com>  $(date -R)
@@ -221,7 +221,7 @@ export DEB_HOST_ARCH=$ARCH
 export DEB_BUILD_OPTIONS="nocheck"
 
 # Set cross-compilation environment for non-native arch
-if [ "$ARCH" != "$(dpkg --print-architecture)" ]; then
+if [ "$DPKG_ARCH" != "$(dpkg --print-architecture)" ]; then
     export DEB_BUILD_PROFILES="cross"
 fi
 
@@ -235,16 +235,16 @@ echo "Package version: $CLEAN_VERSION-1"
 # Build the package
 echo "Starting dpkg-buildpackage..."
 if [ "$DEBUG" = "true" ]; then
-    dpkg-buildpackage -b -us -uc -a$ARCH
+    dpkg-buildpackage -b -us -uc -a$DPKG_ARCH
 else
-    dpkg-buildpackage -b -us -uc -a$ARCH 2>&1 | tee build.log
+    dpkg-buildpackage -b -us -uc -a$DPKG_ARCH 2>&1 | tee build.log
 fi
 
 # Cleanup
 rm -f "openlist-linux-$ARCH.tar.gz"
 
 # Check for generated package
-EXPECTED_DEB="openlist_${CLEAN_VERSION}-1_${ARCH}.deb"
+EXPECTED_DEB="openlist_${CLEAN_VERSION}-1_${DPKG_ARCH}.deb"
 if [ -f "$EXPECTED_DEB" ]; then
     echo "=== Build completed successfully! ==="
     echo "Package file: $EXPECTED_DEB"

--- a/build.sh
+++ b/build.sh
@@ -147,7 +147,7 @@ echo "Dpkg Architecture: $DPKG_ARCH"
 echo "=== Checking for required tools ==="
 MISSING_TOOLS=()
 
-for tool in wget tar dpkg-buildpackage debhelper; do
+for tool in wget tar dpkg-buildpackage dh; do
     if ! command -v $tool &> /dev/null; then
         MISSING_TOOLS+=("$tool")
     fi

--- a/build.sh
+++ b/build.sh
@@ -216,7 +216,7 @@ chmod +x debian/prerm
 chmod +x debian/postrm
 
 # Set environment variables for cross-compilation
-export DEB_HOST_ARCH=$ARCH
+export DEB_HOST_ARCH=$DPKG_ARCH
 export DEB_BUILD_OPTIONS="nocheck"
 
 # Set cross-compilation environment for non-native arch

--- a/build.sh
+++ b/build.sh
@@ -235,9 +235,9 @@ echo "Package version: $CLEAN_VERSION-1"
 # Build the package
 echo "Starting dpkg-buildpackage..."
 if [ "$DEBUG" = "true" ]; then
-    dpkg-buildpackage -us -uc -a$ARCH
+    dpkg-buildpackage -b -us -uc -a$ARCH
 else
-    dpkg-buildpackage -us -uc -a$ARCH 2>&1 | tee build.log
+    dpkg-buildpackage -b -us -uc -a$ARCH 2>&1 | tee build.log
 fi
 
 # Cleanup

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,6 @@ declare -A ARCH_MAP=(
     ["ppc64el"]="ppc64le"
     ["riscv64"]="riscv64"
     ["s390x"]="s390x"
-    ["loongarch64"]="loong64-abi1.0"
     ["loong64"]="loong64"
 )
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: openlist
 Section: utils
 Priority: optional
 Maintainer: OpenListTeam <openlistteam@gmail.com>
-Build-Depends: debhelper (>= 10), wget, curl, tar, jq
+Build-Depends: debhelper (>= 10), wget, tar
 Standards-Version: 4.1.2
 Homepage: https://github.com/OpenListTeam/OpenList
 Vcs-Git: https://github.com/OpenListTeam/OpenList.git

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,14 @@ Source: openlist
 Section: utils
 Priority: optional
 Maintainer: OpenListTeam <openlistteam@gmail.com>
-Build-Depends: debhelper (>= 10), wget
+Build-Depends: debhelper (>= 10), wget, curl, tar, jq
 Standards-Version: 4.1.2
 Homepage: https://github.com/OpenListTeam/OpenList
 Vcs-Git: https://github.com/OpenListTeam/OpenList.git
 Vcs-Browser: https://github.com/OpenListTeam/OpenList
 
 Package: openlist
-Architecture: amd64 arm64
+Architecture: any
 Depends: ${misc:Depends}, systemd, adduser
 Description: OpenList - A modern file management and sharing platform
  OpenList is a powerful file management and sharing platform that provides

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,25 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 DEB_VERSION := $(shell dpkg-parsechangelog -S Version | cut -d- -f1)
 SOURCE_TAG := v$(DEB_VERSION)
 
+# Architecture map for dpkg 
+# "Arch in dpkg" -> "Arch in openlist"
+# See: https://wiki.debian.org/SupportedArchitectures and https://www.debian.org/ports/
+# Note: armel will be removed in Debian 14
+amd64_mapped   := amd64
+i386_mapped    := 386
+arm64_mapped   := arm64
+armel_mapped   := arm-5
+armhf_mapped   := arm-7
+ppc64el_mapped := ppc64le
+riscv64_mapped := riscv64
+s390x_mapped   := s390x
+loong64_mapped := loong64
+
+# Get arch value, return original value if not found
+get_mapped_arch = $(if $(value $(1)_mapped),$(value $(1)_mapped),$(1))
+
+OPENLIST_ARCH := $(call get_mapped_arch,$(DEB_HOST_ARCH))
+
 %:
 	dh $@
 
@@ -15,32 +34,33 @@ override_dh_auto_build:
 	@echo "=== Debian Rules: override_dh_auto_build ==="
 	@echo "Package version: $(DEB_VERSION)"
 	@echo "Source tag: $(SOURCE_TAG)"
-	@echo "Architecture: $(DEB_HOST_ARCH)"
+	@echo "Dpkg Architecture: $(DEB_HOST_ARCH)"
+	@echo "OpenList Architecture: $(OPENLIST_ARCH)"
 	@echo "Build phase - preparing for installation"
 
 override_dh_auto_install:
 	@echo "=== Debian Rules: override_dh_auto_install ==="
 	@echo "Looking for binary for architecture: $(DEB_HOST_ARCH)"
 	# First check if binary is pre-downloaded in debian/binaries/ (for PPA builds)
-	if [ -f "debian/binaries/openlist-linux-$(DEB_HOST_ARCH).tar.gz" ]; then \
+	if [ -f "debian/binaries/openlist-linux-$(OPENLIST_ARCH).tar.gz" ]; then \
 		echo "Found pre-downloaded binary in debian/binaries/"; \
-		cp "debian/binaries/openlist-linux-$(DEB_HOST_ARCH).tar.gz" "openlist-linux-$(DEB_HOST_ARCH).tar.gz"; \
-	elif [ ! -f "openlist-linux-$(DEB_HOST_ARCH).tar.gz" ]; then \
+		cp "debian/binaries/openlist-linux-$(OPENLIST_ARCH).tar.gz" "openlist-linux-$(OPENLIST_ARCH).tar.gz"; \
+	elif [ ! -f "openlist-linux-$(OPENLIST_ARCH).tar.gz" ]; then \
 		echo "Binary archive not found, downloading..."; \
-		echo "Download URL: https://github.com/OpenListTeam/OpenList/releases/download/$(SOURCE_TAG)/openlist-linux-$(DEB_HOST_ARCH).tar.gz"; \
-		wget -O "openlist-linux-$(DEB_HOST_ARCH).tar.gz" \
-			"https://github.com/OpenListTeam/OpenList/releases/download/$(SOURCE_TAG)/openlist-linux-$(DEB_HOST_ARCH).tar.gz" || \
+		echo "Download URL: https://github.com/OpenListTeam/OpenList/releases/download/$(SOURCE_TAG)/openlist-linux-$(OPENLIST_ARCH).tar.gz"; \
+		wget -O "openlist-linux-$(OPENLIST_ARCH).tar.gz" \
+			"https://github.com/OpenListTeam/OpenList/releases/download/$(SOURCE_TAG)/openlist-linux-$(OPENLIST_ARCH).tar.gz" || \
 		(echo "Failed to download binary archive"; exit 1); \
 	fi
 	mkdir -p temp_extract
-	if [ -f "openlist-linux-$(DEB_HOST_ARCH).tar.gz" ]; then \
-		echo "Found binary archive: openlist-linux-$(DEB_HOST_ARCH).tar.gz"; \
-		echo "Archive size: $$(ls -lh openlist-linux-$(DEB_HOST_ARCH).tar.gz | awk '{print $$5}')"; \
+	if [ -f "openlist-linux-$(OPENLIST_ARCH).tar.gz" ]; then \
+		echo "Found binary archive: openlist-linux-$(OPENLIST_ARCH).tar.gz"; \
+		echo "Archive size: $$(ls -lh openlist-linux-$(OPENLIST_ARCH).tar.gz | awk '{print $$5}')"; \
 		echo "Extracting to temporary directory"; \
-		tar -xzf "openlist-linux-$(DEB_HOST_ARCH).tar.gz" -C temp_extract; \
+		tar -xzf "openlist-linux-$(OPENLIST_ARCH).tar.gz" -C temp_extract; \
 		echo "Extraction completed"; \
 	else \
-		echo "Error: Binary archive openlist-linux-$(DEB_HOST_ARCH).tar.gz not found"; \
+		echo "Error: Binary archive openlist-linux-$(OPENLIST_ARCH).tar.gz not found"; \
 		exit 1; \
 	fi
 	@echo "Checking extracted contents:"
@@ -50,7 +70,7 @@ override_dh_auto_install:
 		echo "Contents of extraction directory:"; \
 		find temp_extract/ -type f -exec ls -la {} \; || echo "Directory is empty"; \
 		echo "Checking what was in the archive:"; \
-		tar -tzf "openlist-linux-$(DEB_HOST_ARCH).tar.gz" || echo "Cannot list archive contents"; \
+		tar -tzf "openlist-linux-$(OPENLIST_ARCH).tar.gz" || echo "Cannot list archive contents"; \
 		exit 1; \
 	fi
 	mkdir -p debian/openlist/var/lib/openlist

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
1. 将 Architecture 部分改为 Architecture: any。适合任意架构构建
2. 为 debian/rules 添加架构映射，支持多架构构建
3. 移除 gcc 依赖，添加部分build deps
4. 将 source package formats 改为 3.0 (quilt)。 non-native package 应使用 quilt 而非 native，参考 https://wiki.debian.org/Projects/DebSrc3.0
5. build.sh 中依赖检测部分，将 debhelper 改为 dh。debhelper中的命令实际上是用dh这个wrapper执行的。
6. 在 build.sh 中使用 dpkg-buildpackage -b，仅需构建binary package

已成功构建，参考：https://github.com/multiarchstore/OpenList-APT/releases/tag/v4.1.2