### PR TITLE
fix(ppa): fix debian source package building

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -853,6 +853,16 @@ jobs:
           mkdir -p "openlist-${CLEAN_VERSION}/debian/source" && \
           find "openlist-${CLEAN_VERSION}/debian/binaries/" -type f -printf 'debian/binaries/%P\n' > "openlist-${CLEAN_VERSION}/debian/source/include-binaries" || \
           echo "Warning: Failed to create include-binaries file"
+          
+          # Debug: Verify include-binaries file was created and show its content
+          if [ -f "openlist-${CLEAN_VERSION}/debian/source/include-binaries" ]; then
+            echo "✅ include-binaries file created successfully:"
+            echo "Content of include-binaries file:"
+            cat "openlist-${CLEAN_VERSION}/debian/source/include-binaries"
+          else
+            echo "❌ include-binaries file was not created!"
+            exit 1
+          fi
         else
           echo "❌ No binaries found in source package - this should not happen"
           echo "Contents of source directory:"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -849,11 +849,10 @@ jobs:
         if [ -d "openlist-${CLEAN_VERSION}/debian/binaries" ]; then
           echo "✅ Binaries found in source package:"
           ls -la openlist-${CLEAN_VERSION}/debian/binaries/
-          # Add them into debian/source/include-binaries
-          mkdir -p "openlist-${CLEAN_VERSION}/debian/source"
-          cd "openlist-${CLEAN_VERSION}"
-          find debian/binaries/ -type f -printf 'debian/binaries/%P\n' > debian/source/include-binaries
-          cd ..
+          # Create debian/source/include-binaries to list pre-downloaded binaries
+          mkdir -p "openlist-${CLEAN_VERSION}/debian/source" && \
+          find "openlist-${CLEAN_VERSION}/debian/binaries/" -type f -printf 'debian/binaries/%P\n' > "openlist-${CLEAN_VERSION}/debian/source/include-binaries" || \
+          echo "Warning: Failed to create include-binaries file"
         else
           echo "❌ No binaries found in source package - this should not happen"
           echo "Contents of source directory:"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -851,8 +851,8 @@ jobs:
           ls -la openlist-${CLEAN_VERSION}/debian/binaries/
           # Add them into debian/source/include-binaries
           mkdir -p "openlist-${CLEAN_VERSION}/debian/source"
-          cd "openlist-${CLEAN_VERSION}" && \
-          find debian/binaries/ -type f -printf 'debian/binaries/%P\n' > debian/source/include-binaries && \
+          cd "openlist-${CLEAN_VERSION}"
+          find debian/binaries/ -type f -printf 'debian/binaries/%P\n' > debian/source/include-binaries
           cd ..
         else
           echo "❌ No binaries found in source package - this should not happen"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -852,7 +852,7 @@ jobs:
           # Add them into debian/source/include-binaries
           mkdir -p "openlist-${CLEAN_VERSION}/debian/source"
           cd "openlist-${CLEAN_VERSION}" && \
-          find debian/binaries/ -type f -printf 'debian/binaries/%f\n' > debian/source/include-binaries && \
+          find debian/binaries/ -type f -printf 'debian/binaries/%P\n' > debian/source/include-binaries && \
           cd ..
         else
           echo "❌ No binaries found in source package - this should not happen"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -849,6 +849,11 @@ jobs:
         if [ -d "openlist-${CLEAN_VERSION}/debian/binaries" ]; then
           echo "✅ Binaries found in source package:"
           ls -la openlist-${CLEAN_VERSION}/debian/binaries/
+          # Add them into debian/source/include-binaries
+          mkdir -p "openlist-${CLEAN_VERSION}/debian/source"
+          cd "openlist-${CLEAN_VERSION}" && \
+          find debian/binaries/ -type f -printf 'debian/binaries/%f\n' > debian/source/include-binaries && \
+          cd ..
         else
           echo "❌ No binaries found in source package - this should not happen"
           echo "Contents of source directory:"


### PR DESCRIPTION
修复：https://github.com/OpenListTeam/OpenList-APT/actions/runs/17874358807/job/50833634440 中出现的问题

将预下载的二进制包加入`debian/source/include-binaries`中，以防止dpkg报错